### PR TITLE
Update Rome formula to 0.13.1.35.

### DIFF
--- a/rome.rb
+++ b/rome.rb
@@ -1,10 +1,8 @@
 class Rome < Formula
   desc "A shared cache tool for Carthage on S3"
   homepage "https://github.com/blender/Rome"
-  url "https://github.com/blender/Rome/releases/download/v0.13.0.33/rome.zip"
-  sha256 "ffc96682355c534d6dbbd8f2410c945145bc46af2fda69f3cdffc5cf0090add1"
-
-  version "0.13.0.33"
+  url "https://github.com/blender/Rome/releases/download/v0.13.1.35/rome.zip"
+  sha256 "56216f143e0cdea294319a09868cc4523d7407a1fee733132f12ee5e6299e393"
 
   bottle :unneeded
 


### PR DESCRIPTION
And remove the redundant version from formula since it can be detected
from the URL.